### PR TITLE
ARM64 $INODE64 fix

### DIFF
--- a/mac_alias/osx.py
+++ b/mac_alias/osx.py
@@ -421,11 +421,19 @@ _fgetattrlist = libc.fgetattrlist
 _fgetattrlist.argtypes = [c_int, POINTER(attrlist), c_void_p, c_ulong, c_ulong]
 _fgetattrlist.restype = c_int
 
-_statfs = libc['statfs$INODE64']
+try:
+    _statfs = libc['statfs$INODE64']
+except (KeyError, AttributeError):
+    _statfs = libc['statfs']
+
 _statfs.argtypes = [c_char_p, POINTER(struct_statfs)]
 _statfs.restype = c_int
 
-_fstatfs = libc['fstatfs$INODE64']
+try:
+    _fstatfs = libc['fstatfs$INODE64']
+except (KeyError, AttributeError):
+    _fstatfs = libc['fstatfs']
+
 _fstatfs.argtypes = [c_int, POINTER(struct_statfs)]
 _fstatfs.restype = c_int
 


### PR DESCRIPTION
In [this issue](https://github.com/al45tair/mac_alias/issues/10) I found that python running on OSX arm64 doesn't work with `$INODE64` suffix. 

This PR adds a try/catch block [copied from here](https://assert.cc/posts/darwin_use_64_bit_inode_vs_ctypes/) to try with and without this sufffix.